### PR TITLE
Allow `bib2df()` to read `.bib` which contains a single entry

### DIFF
--- a/R/bib2df_gather.R
+++ b/R/bib2df_gather.R
@@ -10,7 +10,12 @@ bib2df_gather <- function(bib) {
   if (!length(from)) {
     return(empty)
   }
-  itemslist <- mapply(function(x, y) return(bib[x:y]), x = from, y = to - 1)
+  itemslist <- mapply(
+    function(x, y) return(bib[x:y]),
+    x = from,
+    y = to - 1,
+    SIMPLIFY = FALSE
+    )
   keys <- lapply(itemslist,
                  function(x) {
                    str_extract(x[1], "(?<=@\\w{1,50}\\{)((.*)){1}(?=,)")
@@ -73,7 +78,7 @@ bib2df_gather <- function(bib) {
                    }
   )
   values <- lapply(values, trimws)
-  items <- mapply(cbind, categories, values)
+  items <- mapply(cbind, categories, values, SIMPLIFY = FALSE)
   items <- lapply(items,
                   function(x) {
                     x <- cbind(toupper(x[, 1]), x[, 2])
@@ -87,7 +92,7 @@ bib2df_gather <- function(bib) {
   items <- mapply(function(x, y) {
     rbind(x, c("CATEGORY", y))
     },
-    x = items, y = fields)
+    x = items, y = fields, SIMPLIFY = FALSE)
   items <- lapply(items, t)
   items <- lapply(items,
                   function(x) {

--- a/inst/extdata/biblio_one_entry.bib
+++ b/inst/extdata/biblio_one_entry.bib
@@ -1,0 +1,10 @@
+@Article{Binmore2008,
+  Title = {Do Conventions Need to Be Common Knowledge?},
+  Author = {Binmore, Ken},
+  Journal = {Topoi},
+  Year = {2008},
+  Number = {1},
+  Pages = {17--27},
+  Volume = {27}
+}
+

--- a/tests/testthat/tests.R
+++ b/tests/testthat/tests.R
@@ -15,6 +15,23 @@ test_that("bib has correct dimensions", {
   expect_true(ncol(bib) >= 25L)
 })
 
+context("Import .bib with one entry to tibble")
+
+bib1 <- bib2df(system.file("extdata", "biblio_one_entry.bib", package = "bib2df"))
+
+test_that("bib imported as tibble", {
+  expect_true(inherits(bib1, "tbl"))
+})
+
+test_that("bib has correct names", {
+  expect_true(all(names(bib2df:::empty) %in% names(bib1)))
+})
+
+test_that("bib has correct dimensions", {
+  expect_true(nrow(bib1) == 1L)
+  expect_true(ncol(bib1) >= 25L)
+})
+
 context("Export .tbl to .bib")
 
 test_that("df2bib() works", {


### PR DESCRIPTION
Adjusted `bib2df_gather()` so that ingesting `.bib` files with a single entry using `bib2df()` will not throw error. The code uses `mapply()`, which simplifies to array/matrix/vector when possible. Therefore, a `.bib` file with a single entry will return a matrix when a list is expected. Using the `SIMPLIFY = FALSE` parameter corrects this. The fix was tested and test is included in PR.