### PR TITLE
Close #22. Also, made some addtional improvements to df2bib()

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -4,10 +4,11 @@ Title: Parse a BibTeX File to a data.frame
 Version: 1.0.0
 Authors@R: c(person("Philipp", "Ottolinger", email = "philipp@ottolinger.de", role = c("aut", "cre")),
              person("Thomas", "Leeper", email = "thosjleeper@gmail.com", role = "ctb"),
-             person("Maëlle", "Salmon", email = "maelle.salmon@yahoo.se", role = "ctb"))
+             person("Maëlle", "Salmon", email = "maelle.salmon@yahoo.se", role = "ctb"),
+             person("Paul", "Egeler", email = "paulegeler@gmail.com", role = "ctb"))
 Description: Parse a BibTeX file to a data.frame to make it accessible for further analysis and visualization.
-URL: https://github.com/ottlngr/bib2df
-BugReports: http://github.com/ottlngr/bib2df/issues
+URL: https://github.com/ropensci/bib2df
+BugReports: http://github.com/ropensci/bib2df/issues
 License: GPL-3
 LazyData: TRUE
 Imports:

--- a/R/df2bib.R
+++ b/R/df2bib.R
@@ -1,7 +1,7 @@
 #' @title Export a BibTeX \code{tibble} to a .bib file
 #' @description The BibTeX \code{tibble} is written to a .bib file
-#' @param x \code{tibble}, returned by \code{\link{df2bib}}.
-#' @param file character, path to a .bib file.
+#' @param x \code{tibble}, in the format as returned by \code{\link{bib2df}}.
+#' @param file character, file path to write the .bib file. An empty character string writes to \code{stdout} (default).
 #' @param append logical, if \code{TRUE} the \code{tibble} will be appended to an existing file.
 #' @return \code{file} as a character string, invisibly.
 #' @author Thomas J. Leeper
@@ -19,18 +19,18 @@
 #' df2bib(bib, bibFile, append = TRUE)
 #' @seealso \code{\link{bib2df}}
 #' @export
-df2bib <- function(x, file, append = FALSE) {
+df2bib <- function(x, file = "", append = FALSE) {
 
   if (!is.character(file)) {
     stop("Invalid file path: Non-character supplied.", call. = FALSE)
   }
-  if (as.numeric(file.access(dirname(file), mode = 2)) != 0) {
+  if (as.numeric(file.access(dirname(file), mode = 2)) != 0 && file != "") {
     stop("Invalid file path: File is not writeable.", call. = FALSE)
   }
 
-  if (class(x$AUTHOR[[1]]) == "data.frame") {
-    x$AUTHOR <- lapply(x$AUTHOR, na_replace)
-    x$AUTHOR <- lapply(x$AUTHOR,
+  if (any({df_elements <- sapply(x$AUTHOR, inherits, "data.frame")})) {
+    x$AUTHOR[df_elements] <- lapply(x$AUTHOR[df_elements], na_replace)
+    x$AUTHOR[df_elements] <- lapply(x$AUTHOR[df_elements],
                        function(x) {
                          paste(x$last_name,
                                ", ",
@@ -40,7 +40,7 @@ df2bib <- function(x, file, append = FALSE) {
                                sep = "")
                          }
                        )
-    x$AUTHOR <- lapply(x$AUTHOR, trimws)
+    x$AUTHOR[df_elements] <- lapply(x$AUTHOR[df_elements], trimws)
   }
 
   names(x) <- capitalize(names(x))

--- a/man/df2bib.Rd
+++ b/man/df2bib.Rd
@@ -4,12 +4,12 @@
 \alias{df2bib}
 \title{Export a BibTeX \code{tibble} to a .bib file}
 \usage{
-df2bib(x, file, append = FALSE)
+df2bib(x, file = "", append = FALSE)
 }
 \arguments{
-\item{x}{\code{tibble}, returned by \code{\link{df2bib}}.}
+\item{x}{\code{tibble}, in the format as returned by \code{\link{bib2df}}.}
 
-\item{file}{character, path to a .bib file.}
+\item{file}{character, file path to write the .bib file. An empty character string writes to \code{stdout} (default).}
 
 \item{append}{logical, if \code{TRUE} the \code{tibble} will be appended to an existing file.}
 }

--- a/tests/testthat/tests.R
+++ b/tests/testthat/tests.R
@@ -67,7 +67,7 @@ test_that("bib2df() throws error messages", {
   expect_error(bib2df("/a/n/y/where/any.bib"),
                "Invalid file path: File is not readable.",
                fixed = TRUE)
-  expect_error(bib2df("https://www.ottlngr.de/data/x.bib"),
+  expect_error(bib2df("https://www.example.com/data/x.bib"),
                "Invalid URL: File is not readable.",
                fixed = TRUE)
 })


### PR DESCRIPTION
Hello,

I noticed that #22 was an easy win, so I made the change in the documentation for that.

While I was looking at the code, I noticed a few opportunities for extending the function, which I also implemented:

- The user now has the option to write to `stdout`.
- The user can now feed a `tibble` wherein there is a mix of `data.frames` and character vectors in the AUTHORS column. This might arise when the user is binding multiple `tibble`s together (hey, it could happen!!!).

I also took the liberty of updating the URLs to match the transition into the ropensci/bib2df repository, as well as naming myself as a contributor.

Hope that these changes meet with your approval!

Thanks,

Paul