### PR TITLE
fixed regex for scopus (no spaces)

### DIFF
--- a/R/bib2df_gather.R
+++ b/R/bib2df_gather.R
@@ -30,7 +30,7 @@ bib2df_gather <- function(bib) {
 
   categories <- lapply(itemslist,
                        function(x) {
-                         str_extract(x, "[:graph:]+")
+                         str_extract(x, "[[:graph:]][^=]+")
                        }
   )
 


### PR DESCRIPTION
I adjusted the regex so I could parse scopus files. It doesn't seem like I broke anything on the way. See [issue#32](https://github.com/ropensci/bib2df/issues/32#issue-477351401)