### PR TITLE
Replace as_data_frame() by as_tibble()

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -23,6 +23,6 @@ Suggests:
     rmarkdown,
     ggplot2,
     tidyr
-RoxygenNote: 6.1.1
+RoxygenNote: 7.1.0
 VignetteBuilder: knitr
 Encoding: UTF-8

--- a/NAMESPACE
+++ b/NAMESPACE
@@ -3,7 +3,7 @@
 export(bib2df)
 export(df2bib)
 importFrom(dplyr,"%>%")
-importFrom(dplyr,as_data_frame)
+importFrom(dplyr,as_tibble)
 importFrom(dplyr,bind_rows)
 importFrom(dplyr,mutate)
 importFrom(dplyr,select)

--- a/R/bib2df_gather.R
+++ b/R/bib2df_gather.R
@@ -1,7 +1,7 @@
 #' @importFrom stringr str_match
 #' @importFrom stringr str_extract
 #' @importFrom dplyr bind_rows
-#' @importFrom dplyr as_data_frame
+#' @importFrom dplyr as_tibble
 #' @importFrom stats complete.cases
 
 bib2df_gather <- function(bib) {
@@ -95,7 +95,7 @@ bib2df_gather <- function(bib) {
                   }
   )
   dat <- bind_rows(c(list(empty), items))
-  dat <- as_data_frame(dat)
+  dat <- as_tibble(dat)
   dat$BIBTEXKEY <- unlist(keys)
   dat
 }


### PR DESCRIPTION
In order to prevent following warning when using `bib2df()`:

```
`as_data_frame()` is deprecated as of tibble 2.0.0.
Please use `as_tibble()` instead.
The signature and semantics have changed, see `?as_tibble`.
```