### PR TITLE
Fixed issue with logical operators && and || in df2bib()

### DIFF
--- a/R/df2bib.R
+++ b/R/df2bib.R
@@ -24,7 +24,7 @@ df2bib <- function(x, file = "", append = FALSE) {
   if (!is.character(file)) {
     stop("Invalid file path: Non-character supplied.", call. = FALSE)
   }
-  if (as.numeric(file.access(dirname(file), mode = 2)) != 0 && file != "") {
+  if (as.numeric(file.access(dirname(file), mode = 2))[1] != 0 & file != "") {
     stop("Invalid file path: File is not writeable.", call. = FALSE)
   }
 
@@ -52,7 +52,7 @@ df2bib <- function(x, file = "", append = FALSE) {
       if (is.list(f)) {
         f <- unlist(f)
       }
-      rowfields[[i]] <- if (!length(f) || is.na(f)) {
+      rowfields[[i]] <- if (!length(f) | is.na(f)[1]) {
           character(0L)
         } else if (names(x)[i] %in% c("Author", "Editor")) {
           paste(f, collapse = " and ")


### PR DESCRIPTION
Following the R release 4.2.0, the logical operators `&&` and `||` throw a warning (soon to be an error) when one side of the logical comparison is a vector of length greater than 1. Since both operators compare the first element of the vector by construction, I made them do this more explicitly.

For more on `&&` and `||` see [their documentation](https://stat.ethz.ch/R-manual/R-devel/library/base/html/Logic.html) and specifically the following quote:

> *Using vectors of more than one element in && or || will give a warning (as from R 4.2.0), or an error if the environment variable _R_CHECK_LENGTH_1_LOGIC2_ is set to a true value (this is intended to become the default in future).*
