### PR TITLE
Update df2bib.R to avoid error with newer versions of R

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,12 +1,13 @@
 Package: bib2df
 Type: Package
 Title: Parse a BibTeX File to a Data Frame
-Version: 1.1.2
+Version: 1.1.2.0
 Authors@R: c(person("Philipp", "Ottolinger", email = "philipp@ottolinger.de", role = c("aut", "cre")),
              person("Thomas", "Leeper", email = "thosjleeper@gmail.com", role = "ctb"),
              person("Maëlle", "Salmon", email = "maelle.salmon@yahoo.se", role = "ctb"),
              person("Paul", "Egeler", email = "paulegeler@gmail.com", role = "ctb"),
-             person("Emilio Xavier", "Esposito", email = "emilio.esposito@gmail.com", role = "ctb"))
+             person("Emilio Xavier", "Esposito", email = "emilio.esposito@gmail.com", role = "ctb"),
+             person("Gianluca", "Baio", email = "g.baio@ucl.ac.uk", role = "ctb"))
 Description: Parse a BibTeX file to a data.frame to make it accessible for further analysis and visualization.
 URL: https://docs.ropensci.org/bib2df, https://github.com/ropensci/bib2df
 BugReports: http://github.com/ropensci/bib2df/issues

--- a/R/df2bib.R
+++ b/R/df2bib.R
@@ -5,6 +5,7 @@
 #' @param append logical, if \code{TRUE} the \code{tibble} will be appended to an existing file.
 #' @return \code{file} as a character string, invisibly.
 #' @author Thomas J. Leeper
+#' @author Gianluca Baio
 #' @references \url{http://www.bibtex.org/Format/}
 #' @examples
 #' # Read from .bib file:
@@ -52,7 +53,7 @@ df2bib <- function(x, file = "", append = FALSE) {
       if (is.list(f)) {
         f <- unlist(f)
       }
-      rowfields[[i]] <- if (!length(f) || is.na(f)) {
+      rowfields[[i]] <- if (!length(f) | any(is.na(f))) {
           character(0L)
         } else if (names(x)[i] %in% c("Author", "Editor")) {
           paste(f, collapse = " and ")
@@ -61,7 +62,7 @@ df2bib <- function(x, file = "", append = FALSE) {
         }
     }
     rowfields <- rowfields[lengths(rowfields) > 0]
-    rowfields <- rowfields[!names(rowfields) %in% c("Category", "Bibtexkey")]
+    rowfields <- rowfields[!names(rowfields) %in% c("CATEGORY", "BIBTEXKEY")]
     paste0("  ",
            names(rowfields),
            " = {",
@@ -70,9 +71,9 @@ df2bib <- function(x, file = "", append = FALSE) {
            collapse = ",\n")
   })
   cat(paste0("@",
-             capitalize(x$Category),
+             capitalize(x$CATEGORY),
              "{",
-             x$Bibtexkey,
+             x$BIBTEXKEY,
              ",\n",
              unlist(fields),
              "\n}\n",


### PR DESCRIPTION
This is necessary; newer versions of R throw an error, which is mainly due to the use of `||` in `df2bib.R` + a problem with the naming of the variables in the created dataframe (upper/lowercase). This PR sorts them now and makes `bib2df` usable, AFAIK.