### PR TITLE
Update warnings on malformed files

### DIFF
--- a/R/bib2df_gather.R
+++ b/R/bib2df_gather.R
@@ -4,6 +4,7 @@
 #' @importFrom dplyr as_tibble
 #' @importFrom stats complete.cases
 
+
 bib2df_gather <- function(bib) {
 
   from <- which(str_extract(bib, "[:graph:]") == "@")
@@ -44,7 +45,8 @@ bib2df_gather <- function(bib) {
   )
 
   if (dupl > 0) {
-    message("Some BibTeX entries may have been dropped.
+    warning("There were issues with the syntax of the bibTeX.file.
+            Some BibTeX entries may have been dropped.
             The result could be malformed.
             Review the .bib file and make sure every single entry starts
             with a '@' and that there are no duplicates entries (same key) or duplicate fields within an entry.")

--- a/R/bib2df_gather.R
+++ b/R/bib2df_gather.R
@@ -47,7 +47,7 @@ bib2df_gather <- function(bib) {
     message("Some BibTeX entries may have been dropped.
             The result could be malformed.
             Review the .bib file and make sure every single entry starts
-            with a '@'.")
+            with a '@' and that there are no duplicates entries (same key) or duplicate fields within an entry.")
   }
 
   values <- lapply(itemslist,

--- a/R/bib2df_tidy.R
+++ b/R/bib2df_tidy.R
@@ -14,7 +14,7 @@ bib2df_tidy <- function(bib, separate_names = FALSE) {
   AUTHOR <- EDITOR <- YEAR <- CATEGORY <- NULL
   if ("AUTHOR" %in% colnames(bib)) {
     bib <- bib %>%
-      mutate(AUTHOR = strsplit(AUTHOR, " and ", fixed = TRUE))
+      dplyr::mutate(AUTHOR = strsplit(AUTHOR, " and ", fixed = TRUE))
     if (separate_names) {
       bib$AUTHOR <- lapply(bib$AUTHOR, function(x) x %>%
                              format_reverse() %>%
@@ -35,13 +35,13 @@ bib2df_tidy <- function(bib, separate_names = FALSE) {
   if ("YEAR" %in% colnames(bib)) {
     if (sum(is.na(as.numeric(bib$YEAR))) == 0) {
       bib <- bib %>%
-        mutate(YEAR = as.numeric(YEAR))
+        dplyr::mutate(YEAR = as.numeric(YEAR))
     } else {
       message("Column `YEAR` contains character strings.
               No coercion to numeric applied.")
     }
   }
   bib <- bib %>%
-    select(CATEGORY, dplyr::everything())
+    dplyr::select(CATEGORY, dplyr::everything())
   return(bib)
 }


### PR DESCRIPTION
I was thinking of helping with #54 , but then I thought a bit more and I realised that this is actually not a wanted behaviour, afaik.

Bibtex entries should not include duplicate fields. I updated the warning in bib2df_gather to spell out some more of the potential problems that trigger that message.